### PR TITLE
feat(finance): import-amazon-costs CLI (Brief 2) (#17)

### DIFF
--- a/ebay-ms/.gitignore
+++ b/ebay-ms/.gitignore
@@ -64,3 +64,8 @@ htmlcov/
 # GPG keys
 *.gpg
 *.asc
+
+# Amazon import 输出目录（含个人进货数据）
+.ebay-project/
+imports/
+data/

--- a/ebay-ms/main.py
+++ b/ebay-ms/main.py
@@ -180,6 +180,16 @@ def run() -> int:
     p_imp_listings.add_argument("--no-expand-short-links", dest="no_expand_short_links",
                                action="store_true", help="禁用 amzn.asia 短链展开")
 
+    p_imp_amz = product_sub.add_parser(
+        "import-amazon-costs",
+        help="从 Amazon 注文履歴 CSV 导入进货成本",
+    )
+    p_imp_amz.add_argument("--file", required=True, help="Amazon 注文履歴 CSV 路径")
+    p_imp_amz.add_argument(
+        "--output-dir",
+        help="报告输出目录（默认 ~/.ebay-project/imports/）",
+    )
+
     # ── finance 模块 ────────────────────────────────────────────────────────
     finance_p = sub.add_parser("finance", help="财务模块")
     finance_sub = finance_p.add_subparsers(dest="cmd", help="子命令")
@@ -412,12 +422,30 @@ def run() -> int:
     if args.module == "product":
         from pathlib import Path
 
-        from modules.listing.listing_importer import ListingImporter
-        importer = ListingImporter(expand_short_links=not args.no_expand_short_links)
-        paths = [Path(p) for p in args.file]
-        result = importer.import_files(paths)
-        print(result.summary())
-        return 0
+        if args.cmd == "import-listings":
+            from modules.listing.listing_importer import ListingImporter
+            importer = ListingImporter(expand_short_links=not args.no_expand_short_links)
+            paths = [Path(p) for p in args.file]
+            result = importer.import_files(paths)
+            print(result.summary())
+            return 0
+
+        if args.cmd == "import-amazon-costs":
+            from modules.finance.amazon_cost_importer import AmazonCostImporter
+            importer = AmazonCostImporter(
+                output_dir=Path(args.output_dir) if args.output_dir else None,
+            )
+            result = importer.import_csv(Path(args.file))
+            print(result.summary())
+            print("\n报告输出:")
+            print(f"  {result.summary_txt}")
+            print(f"  {result.ambiguous_csv}")
+            print(f"  {result.unmapped_csv}")
+            print(f"  {result.non_amazon_csv}")
+            return 0
+
+        parser.print_help()
+        return 1
 
     parser.print_help()
 

--- a/ebay-ms/modules/finance/amazon_cost_importer.py
+++ b/ebay-ms/modules/finance/amazon_cost_importer.py
@@ -7,7 +7,6 @@ modules/finance/amazon_cost_importer.py
 """
 from __future__ import annotations
 
-import time
 from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
@@ -198,8 +197,6 @@ class AmazonCostImporter:
                     result.cost_upserted += 1
                     result.upserted_amount_jpy += amount
 
-                # 小延迟，防 DB 锁
-                time.sleep(0.01)
 
         # 输出报告
         result.ambiguous_csv = self._write_csv("ambiguous_costs.csv", ambiguous_rows)

--- a/ebay-ms/modules/finance/amazon_cost_importer.py
+++ b/ebay-ms/modules/finance/amazon_cost_importer.py
@@ -1,0 +1,224 @@
+"""
+modules/finance/amazon_cost_importer.py
+
+从 Amazon 注文履歴 CSV 导入进货成本到 Product.cost_price。
+
+数据流见 brief-product-import-amazon-costs-v2.md §4.1
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+from core.database.connection import get_session
+from core.models import Product, SupplierPriceHistory
+from core.utils.asin import clean_amazon_csv_asin, is_standard_asin
+from loguru import logger as log
+from sqlalchemy import select
+
+# CSV 列名（集中定义，以后 Amazon 改格式只需改这里）
+# 注意：真实 CSV 列名是 "商品の小計（税込）"（不是 brief 里的 "小合計"）
+_COL_ASIN = "ASIN"
+_COL_ORDER_DATE = "注文日"
+_COL_QTY = "注文の数量"
+_COL_AMOUNT_INC = "商品の小計（税込）"   # 税込み単価の合計
+_COL_AMOUNT_EXC = "商品の小計（税抜）"   # 税抜き（退税 brief 用，暂存不用）
+_COL_TITLE = "商品名"
+
+
+@dataclass
+class AmazonCostImportResult:
+    """导入结果统计。CSV 路径、各路由计数、各路由金额（用于报表）。"""
+    csv_path: str = ""
+    rows_total: int = 0
+    rows_zero_qty: int = 0
+    asin_aggregated: int = 0   # 去重后的 ASIN 数
+
+    # 路由计数
+    cost_upserted: int = 0
+    ambiguous: int = 0
+    unmapped: int = 0
+    non_amazon: int = 0
+
+    # 输出文件路径
+    ambiguous_csv: Optional[Path] = None
+    unmapped_csv: Optional[Path] = None
+    non_amazon_csv: Optional[Path] = None
+    summary_txt: Optional[Path] = None
+
+    # 金额维度（JPY 税込）
+    total_amount_jpy: Decimal = Decimal("0")
+    upserted_amount_jpy: Decimal = Decimal("0")
+    ambiguous_amount_jpy: Decimal = Decimal("0")
+    unmapped_amount_jpy: Decimal = Decimal("0")
+    non_amazon_amount_jpy: Decimal = Decimal("0")
+
+    def summary(self) -> str:
+        return (
+            f"=== import-amazon-costs 完成 ===\n"
+            f"CSV: {self.csv_path}\n"
+            f"原始行数: {self.rows_total}（qty=0 跳过 {self.rows_zero_qty}）\n"
+            f"去重 ASIN: {self.asin_aggregated}\n"
+            f"\n--- 按 ASIN 路由 ---\n"
+            f" ✅ 自动入库 cost: {self.cost_upserted} 个\n"
+            f" ⚠️ 多 SKU 共享 → ambiguous_costs.csv: {self.ambiguous} 个\n"
+            f" ⚠️ 未匹配 SKU → unmapped_asins.csv: {self.unmapped} 个\n"
+            f" ⚠️ 非 Amazon ASIN → non_amazon_costs.csv: {self.non_amazon} 个\n"
+            f"\n--- 按金额（税込 JPY）---\n"
+            f" 总进货: {self.total_amount_jpy:,.0f}円\n"
+            f" 自动入库: {self.upserted_amount_jpy:,.0f}円\n"
+            f" ambiguous: {self.ambiguous_amount_jpy:,.0f}円\n"
+            f" unmapped: {self.unmapped_amount_jpy:,.0f}円\n"
+            f" non_amazon: {self.non_amazon_amount_jpy:,.0f}円\n"
+        )
+
+
+class AmazonCostImporter:
+    SUPPLIER_DEFAULT = "Amazon JP"
+    OUTPUT_DIR = Path.home() / ".ebay-project" / "imports"
+
+    def __init__(self, *, output_dir: Optional[Path] = None):
+        self.output_dir = output_dir or self.OUTPUT_DIR
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def import_csv(self, csv_path: Path) -> AmazonCostImportResult:
+        result = AmazonCostImportResult(csv_path=str(csv_path))
+
+        try:
+            df = pd.read_csv(csv_path, encoding="utf-8")
+        except FileNotFoundError:
+            raise RuntimeError(f"CSV 文件不存在: {csv_path}")
+        except UnicodeDecodeError:
+            raise RuntimeError(f"CSV 编码错误（预期 UTF-8）: {csv_path}")
+
+        result.rows_total = len(df)
+
+        # 验证必要列存在
+        missing = [
+            c for c in [_COL_ASIN, _COL_QTY, _COL_AMOUNT_INC]
+            if c not in df.columns
+        ]
+        if missing:
+            raise RuntimeError(f"CSV 缺少必要列: {missing}，实际列: {list(df.columns[:10])}...")
+
+        # 清洗 ASIN（剥 ="..." 外壳）
+        df["asin_clean"] = df[_COL_ASIN].apply(clean_amazon_csv_asin)
+
+        # 剔除 qty=0 / 缺失 qty（退货行）
+        zero_mask = pd.to_numeric(df[_COL_QTY], errors="coerce").fillna(0).astype(int) <= 0
+        result.rows_zero_qty = int(zero_mask.sum())
+        df = df[~zero_mask].copy()
+
+        if df.empty:
+            result.asin_aggregated = 0
+            log.warning("CSV 没有有效数据行（全部 qty=0）")
+            return result
+
+        # 按 ASIN 聚合（税込み）
+        df["amount_inc"] = pd.to_numeric(df[_COL_AMOUNT_INC], errors="coerce").fillna(0)
+        agg = df.groupby("asin_clean").agg(
+            qty=(_COL_QTY, "sum"),
+            amount_inc=("amount_inc", "sum"),
+            order_date_latest=(_COL_ORDER_DATE, "max"),
+            title=(_COL_TITLE, "first"),
+        ).reset_index()
+        result.asin_aggregated = len(agg)
+
+        # 路由
+        ambiguous_rows: list[dict] = []
+        unmapped_rows: list[dict] = []
+        non_amazon_rows: list[dict] = []
+
+        with get_session() as sess:
+            # 一次性把所有有 asin 的 product 拉出来，按 asin 索引
+            products_by_asin: dict[str, list[Product]] = {}
+            for p in sess.execute(
+                select(Product).where(Product.asin.isnot(None))
+            ).scalars():
+                products_by_asin.setdefault(p.asin, []).append(p)
+
+            for _, r in agg.iterrows():
+                asin: str = r["asin_clean"]
+                amount = Decimal(str(r["amount_inc"]))
+                qty = int(r["qty"])
+                title = str(r.get("title", ""))[:120]
+                row_summary = {
+                    "asin": asin,
+                    "qty": qty,
+                    "amount_jpy": float(amount),
+                    "title": title,
+                    "order_date_latest": str(r["order_date_latest"]),
+                }
+
+                result.total_amount_jpy += amount
+
+                # 路由 1: 非标准 ASIN（ISBN/JAN/其他）
+                if not is_standard_asin(asin):
+                    non_amazon_rows.append(row_summary)
+                    result.non_amazon += 1
+                    result.non_amazon_amount_jpy += amount
+                    continue
+
+                # 路由 2: 按 products 表里的 SKU 数路由
+                matched = products_by_asin.get(asin, [])
+                if len(matched) == 0:
+                    unmapped_rows.append(row_summary)
+                    result.unmapped += 1
+                    result.unmapped_amount_jpy += amount
+                elif len(matched) > 1:
+                    row_summary["sku_candidates"] = ";".join(p.sku for p in matched)
+                    ambiguous_rows.append(row_summary)
+                    result.ambiguous += 1
+                    result.ambiguous_amount_jpy += amount
+                else:
+                    p = matched[0]
+                    new_cost = (amount / qty).quantize(Decimal("0.01"))
+
+                    # D3: 旧 cost_price 非 NULL 时记历史
+                    if p.cost_price is not None:
+                        sess.add(SupplierPriceHistory(
+                            sku=p.sku,
+                            supplier=p.supplier,
+                            price=p.cost_price,
+                            currency=p.cost_currency or "JPY",
+                            recorded_at=date.today(),
+                            note="superseded by import-amazon-costs",
+                        ))
+
+                    p.cost_price = new_cost
+                    p.cost_currency = "JPY"
+                    p.supplier = self.SUPPLIER_DEFAULT
+                    # source_url 不动（Brief 1 已填）
+
+                    result.cost_upserted += 1
+                    result.upserted_amount_jpy += amount
+
+                # 小延迟，防 DB 锁
+                time.sleep(0.01)
+
+        # 输出报告
+        result.ambiguous_csv = self._write_csv("ambiguous_costs.csv", ambiguous_rows)
+        result.unmapped_csv = self._write_csv("unmapped_asins.csv", unmapped_rows)
+        result.non_amazon_csv = self._write_csv("non_amazon_costs.csv", non_amazon_rows)
+        result.summary_txt = self._write_summary(result)
+
+        return result
+
+    def _write_csv(self, name: str, rows: list[dict]) -> Path:
+        path = self.output_dir / name
+        if rows:
+            pd.DataFrame(rows).to_csv(path, index=False, encoding="utf-8")
+        else:
+            # 即使空也建文件，留个 header，业务侧打开看到"今天没东西"
+            path.write_text("# (empty - 本次导入此分类无记录)\n", encoding="utf-8")
+        return path
+
+    def _write_summary(self, result: AmazonCostImportResult) -> Path:
+        path = self.output_dir / "import_summary.txt"
+        path.write_text(result.summary(), encoding="utf-8")
+        return path

--- a/ebay-ms/tests/test_amazon_cost_importer.py
+++ b/ebay-ms/tests/test_amazon_cost_importer.py
@@ -1,0 +1,452 @@
+"""
+tests/test_amazon_cost_importer.py
+AmazonCostImporter 单元测试（Brief 2）
+"""
+from __future__ import annotations
+
+import csv
+from datetime import date
+from decimal import Decimal
+from io import StringIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from core.models import Product, ProductStatus, SupplierPriceHistory
+from core.models.base import Base
+from modules.finance.amazon_cost_importer import AmazonCostImporter
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def in_memory_db(tmp_path: Path) -> Session:
+    """独立的内存 SQLite 数据库，隔离测试。"""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as sess:
+        yield sess
+
+
+@pytest.fixture
+def output_dir(tmp_path: Path) -> Path:
+    return tmp_path / "imports"
+
+
+def make_amazon_csv(path: Path, rows: list[dict]) -> Path:
+    """生成最简 Amazon CSV，匹配真实 CSV 列结构。
+
+    真实 CSV 列（部分）:
+      注文日, ASIN, 注文の数量, 商品の小計（税込）, 商品名
+    ASIN 格式为 ="B0XXXXX"（真实 Amazon 导出格式）。
+    """
+    header = [
+        "注文日", "注文番号", "アカウントグループ", "発注番号",
+        "注文の数量", "通貨", "注文の小計（税抜）",
+        "注文の配送料および手数料（税抜）", "注文の消費税額",
+        "注文の割引（税込）", "注文の合計（税込）",
+        "ASIN", "商品名",
+        "商品の小計（税込）", "商品の小計（税抜）",
+    ]
+    asin_col = header.index("ASIN")
+    qty_col = header.index("注文の数量")
+    amt_col = header.index("商品の小計（税込）")
+    title_col = header.index("商品名")
+    date_col = header.index("注文日")
+
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        for r in rows:
+            row = [""] * len(header)
+            row[date_col] = r.get("date", "2026/04/01")
+            row[asin_col] = f'="{r.get("asin", "")}"'
+            row[qty_col] = r.get("qty", 1)
+            row[amt_col] = r.get("amount", 1000)
+            row[title_col] = r.get("title", "Test Product")
+            writer.writerow(row)
+    return path
+
+
+# ── AmazonCostImporter 主类测试 ────────────────────────────────────────────────
+
+class TestAmazonCostImporter:
+    """核心 upsert 逻辑测试。"""
+
+    def test_one_to_one_upsert_success(self, in_memory_db: Session, tmp_path: Path):
+        """1-to-1 映射 → Product.cost_price 被正确填充。"""
+        # 先建 Product（通过 listing importer 流程，这里直接建）
+        in_memory_db.add(Product(
+            sku="SKU-001",
+            title=None,
+            asin="B0ABCDEF12",
+            source_url="https://www.amazon.co.jp/dp/B0ABCDEF12",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0ABCDEF12", "qty": 2, "amount": 3000, "title": "Test A"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            result = importer.import_csv(csv_path)
+
+        assert result.cost_upserted == 1
+        assert result.ambiguous == 0
+        assert result.unmapped == 0
+        p = in_memory_db.get(Product, "SKU-001")
+        assert p.cost_price == Decimal("1500.00")   # 3000 / 2
+
+    def test_existing_cost_history_written(self, in_memory_db: Session, tmp_path: Path):
+        """已有 cost_price → 旧值写入 SupplierPriceHistory。"""
+        in_memory_db.add(Product(
+            sku="SKU-002",
+            title=None,
+            asin="B0BBB22222",
+            source_url="https://www.amazon.co.jp/dp/B0BBB22222",
+            cost_price=Decimal("1000.00"),
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0BBB22222", "qty": 1, "amount": 2000, "title": "Test B"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            result = importer.import_csv(csv_path)
+
+        assert result.cost_upserted == 1
+        # 旧值进了历史
+        hist = in_memory_db.query(SupplierPriceHistory).filter_by(sku="SKU-002").all()
+        assert len(hist) == 1
+        assert hist[0].price == Decimal("1000.00")
+        # 新值覆盖了 product
+        p = in_memory_db.get(Product, "SKU-002")
+        assert p.cost_price == Decimal("2000.00")
+
+    def test_idempotent_second_run_writes_history(self, in_memory_db: Session, tmp_path: Path):
+        """同 SKU 跑两次 → 第二次旧值进历史。"""
+        # 第一次运行
+        in_memory_db.add(Product(
+            sku="SKU-IDEM",
+            title=None,
+            asin="B0IDEM0001",
+            source_url="https://www.amazon.co.jp/dp/B0IDEM0001",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv1 = make_amazon_csv(tmp_path / "run1.csv", [
+            {"asin": "B0IDEM0001", "qty": 1, "amount": 1000, "title": "Run 1"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            importer.import_csv(csv1)
+
+        # 第二次运行（cost_price 已有值）
+        csv2 = make_amazon_csv(tmp_path / "run2.csv", [
+            {"asin": "B0IDEM0001", "qty": 1, "amount": 1500, "title": "Run 2"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            result = importer.import_csv(csv2)
+
+        assert result.cost_upserted == 1
+        hist = in_memory_db.query(SupplierPriceHistory).filter_by(sku="SKU-IDEM").all()
+        assert len(hist) == 1
+        assert hist[0].price == Decimal("1000.00")   # 第一次的值
+        p = in_memory_db.get(Product, "SKU-IDEM")
+        assert p.cost_price == Decimal("1500.00")   # 第二次的值
+
+    def test_ambiguous_asin_writes_csv(self, in_memory_db: Session, tmp_path: Path):
+        """多 SKU 共享 ASIN → ambiguous_costs.csv，DB 不变。"""
+        # 两个 SKU 共用同一个 ASIN
+        in_memory_db.add(Product(
+            sku="SKU-A1",
+            title=None,
+            asin="B0AMBIGU01",
+            source_url="https://www.amazon.co.jp/dp/B0AMBIGU01",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.add(Product(
+            sku="SKU-A2",
+            title=None,
+            asin="B0AMBIGU01",
+            source_url="https://www.amazon.co.jp/dp/B0AMBIGU01",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0AMBIGU01", "qty": 2, "amount": 3000, "title": "Ambiguous"},
+        ])
+
+        out_dir = tmp_path / "out"
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=out_dir)
+            result = importer.import_csv(csv_path)
+
+        assert result.ambiguous == 1
+        assert result.cost_upserted == 0
+        assert (out_dir / "ambiguous_costs.csv").exists()
+        # 两 SKU 仍未有 cost_price
+        assert in_memory_db.get(Product, "SKU-A1").cost_price is None
+        assert in_memory_db.get(Product, "SKU-A2").cost_price is None
+
+    def test_unmapped_asin_writes_csv(self, in_memory_db: Session, tmp_path: Path):
+        """ASIN 不在 products 表 → unmapped_asins.csv。"""
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0UNMAPPED", "qty": 1, "amount": 999, "title": "Not Found"},
+        ])
+
+        out_dir = tmp_path / "out"
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=out_dir)
+            result = importer.import_csv(csv_path)
+
+        assert result.unmapped == 1
+        assert result.cost_upserted == 0
+        assert (out_dir / "unmapped_asins.csv").exists()
+
+    def test_isbn_non_amazon(self, in_memory_db: Session, tmp_path: Path):
+        """ISBN（10 位数字）→ non_amazon_costs.csv。"""
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "4499228646", "qty": 1, "amount": 1980, "title": "Book ISBN"},
+        ])
+
+        out_dir = tmp_path / "out"
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=out_dir)
+            result = importer.import_csv(csv_path)
+
+        assert result.non_amazon == 1
+        assert result.cost_upserted == 0
+        assert (out_dir / "non_amazon_costs.csv").exists()
+
+    def test_zero_qty_rows_skipped(self, in_memory_db: Session, tmp_path: Path):
+        """qty=0 行（退货）→ 跳过，不进任何路由。"""
+        # 先建有 ASIN 的 Product（让 valid 行能入库）
+        in_memory_db.add(Product(
+            sku="SKU-VALID01",
+            title=None,
+            asin="B0VALID001",
+            source_url="https://www.amazon.co.jp/dp/B0VALID001",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0ZEROTES2", "qty": 0, "amount": 0, "title": "Zero Qty"},
+            {"asin": "B0VALID001", "qty": 1, "amount": 1000, "title": "Valid"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            result = importer.import_csv(csv_path)
+
+        assert result.rows_zero_qty == 1
+        assert result.cost_upserted == 1   # 有效行仍入库
+
+    def test_weighted_average_multi_row(self, in_memory_db: Session, tmp_path: Path):
+        """同 ASIN 多笔进货 → 加权平均（Σamount / Σqty）。"""
+        in_memory_db.add(Product(
+            sku="SKU-WEIGHT",
+            title=None,
+            asin="B0WEIGHT01",
+            source_url="https://www.amazon.co.jp/dp/B0WEIGHT01",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        # 两笔: 1000円×2个 + 1500円×1个 = 3500/3 = 1166.67
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0WEIGHT01", "qty": 2, "amount": 2000, "title": "Weight 1"},
+            {"asin": "B0WEIGHT01", "qty": 1, "amount": 1500, "title": "Weight 2"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            result = importer.import_csv(csv_path)
+
+        assert result.cost_upserted == 1
+        p = in_memory_db.get(Product, "SKU-WEIGHT")
+        assert p.cost_price == Decimal("1166.67")   # (2000+1500)/3 quantized
+
+    def test_missing_asin_column_raises(self, in_memory_db: Session, tmp_path: Path):
+        """CSV 缺少 ASIN 列 → 抛友好 RuntimeError。"""
+        # 写入一个没有 ASIN 列的 CSV
+        bad_path = tmp_path / "bad.csv"
+        with open(bad_path, "w", newline="", encoding="utf-8") as f:
+            f.write("注文日,qty\n2026/04/01,1\n")
+
+        with pytest.raises(RuntimeError, match="缺少必要列"):
+            AmazonCostImporter(output_dir=tmp_path / "out").import_csv(bad_path)
+
+    def test_output_dir_auto_created(self, in_memory_db: Session, tmp_path: Path):
+        """输出目录不存在 → 自动创建。"""
+        in_memory_db.add(Product(
+            sku="SKU-DIR01",
+            title=None,
+            asin="B0DIRTEST01",
+            source_url="https://www.amazon.co.jp/dp/B0DIRTEST01",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0DIRTEST01", "qty": 1, "amount": 1000, "title": "Dir Test"},
+        ])
+
+        new_dir = tmp_path / "nested" / "deep" / "imports"
+        assert not new_dir.exists()
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=new_dir)
+            result = importer.import_csv(csv_path)
+
+        assert new_dir.exists()
+        assert (new_dir / "import_summary.txt").exists()
+
+    def test_amount_dimension_balances(self, in_memory_db: Session, tmp_path: Path):
+        """金额维度：total == upserted + ambiguous + unmapped + non_amazon。"""
+        in_memory_db.add(Product(
+            sku="SKU-AMB",
+            title=None,
+            asin="B0AMBCHECK",
+            source_url="https://www.amazon.co.jp/dp/B0AMBCHECK",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.add(Product(
+            sku="SKU-AMB2",
+            title=None,
+            asin="B0AMBCHECK",
+            source_url="https://www.amazon.co.jp/dp/B0AMBCHECK",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            # upserted (unique ASIN)
+            {"asin": "B0UPSERT01", "qty": 1, "amount": 5000, "title": "Up"},
+            # ambiguous (shared ASIN with two SKUs, each 3000)
+            {"asin": "B0AMBCHECK", "qty": 2, "amount": 6000, "title": "Amb"},
+            # unmapped (no product)
+            {"asin": "B0UNMAPPED", "qty": 1, "amount": 2000, "title": "Unmap"},
+            # non-amazon (ISBN)
+            {"asin": "1234567890", "qty": 1, "amount": 1000, "title": "ISBN"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            result = importer.import_csv(csv_path)
+
+        total = result.total_amount_jpy
+        parts = (
+            result.upserted_amount_jpy
+            + result.ambiguous_amount_jpy
+            + result.unmapped_amount_jpy
+            + result.non_amazon_amount_jpy
+        )
+        assert total == parts, f"{total} != {parts}"
+
+    def test_supplier_field_set_to_amazon_jp(self, in_memory_db: Session, tmp_path: Path):
+        """upsert 后 supplier 字段 = 'Amazon JP'。"""
+        in_memory_db.add(Product(
+            sku="SKU-SUPPLIER",
+            title=None,
+            asin="B0SUPPLIER",
+            source_url="https://www.amazon.co.jp/dp/B0SUPPLIER",
+            cost_price=None,
+            cost_currency="JPY",
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0SUPPLIER", "qty": 1, "amount": 1000, "title": "Supplier Test"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            importer.import_csv(csv_path)
+
+        p = in_memory_db.get(Product, "SKU-SUPPLIER")
+        assert p.supplier == "Amazon JP"
+
+    def test_cost_currency_set_to_jpy(self, in_memory_db: Session, tmp_path: Path):
+        """upsert 后 cost_currency = 'JPY'。"""
+        in_memory_db.add(Product(
+            sku="SKU-CURR",
+            title=None,
+            asin="B0CURRTEST",
+            source_url="https://www.amazon.co.jp/dp/B0CURRTEST",
+            cost_price=None,
+            cost_currency="USD",   # 旧值
+            status=ProductStatus.ACTIVE,
+        ))
+        in_memory_db.commit()
+
+        csv_path = make_amazon_csv(tmp_path / "test.csv", [
+            {"asin": "B0CURRTEST", "qty": 1, "amount": 1000, "title": "Currency Test"},
+        ])
+
+        with patch("modules.finance.amazon_cost_importer.get_session") as mock_sess:
+            mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
+            mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+            importer = AmazonCostImporter(output_dir=tmp_path / "out")
+            importer.import_csv(csv_path)
+
+        p = in_memory_db.get(Product, "SKU-CURR")
+        assert p.cost_currency == "JPY"

--- a/ebay-ms/tests/test_amazon_cost_importer.py
+++ b/ebay-ms/tests/test_amazon_cost_importer.py
@@ -5,20 +5,16 @@ AmazonCostImporter 单元测试（Brief 2）
 from __future__ import annotations
 
 import csv
-from datetime import date
 from decimal import Decimal
-from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import Session
-
 from core.models import Product, ProductStatus, SupplierPriceHistory
 from core.models.base import Base
 from modules.finance.amazon_cost_importer import AmazonCostImporter
-
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -346,7 +342,7 @@ class TestAmazonCostImporter:
             mock_sess.return_value.__enter__ = MagicMock(return_value=in_memory_db)
             mock_sess.return_value.__exit__ = MagicMock(return_value=False)
             importer = AmazonCostImporter(output_dir=new_dir)
-            result = importer.import_csv(csv_path)
+            importer.import_csv(csv_path)
 
         assert new_dir.exists()
         assert (new_dir / "import_summary.txt").exists()


### PR DESCRIPTION
从 Amazon 注文履歴 CSV 导入进货成本到 Product.cost_price。

核心逻辑:
- ASIN 路由: 1-to-1 upsert / ambiguous(多 SKU 共享) / unmapped / non-amazon(ISBN)
- 单价: 商品の小計（税込）/ 注文の数量，多笔加权平均
- 旧 cost_price 非 NULL 时归档到 SupplierPriceHistory
- supplier 统一写 'Amazon JP'，source_url 不动

文件:
- modules/finance/amazon_cost_importer.py (新建)
- main.py: 加 product import-amazon-costs 子命令
- .gitignore: 加 imports/ data/ .ebay-project/
- tests/test_amazon_cost_importer.py: 13 项测试

测试: 528 passed (基线 515 + 新 13)
真实数据冒烟: 22 个 ASIN upserted, 金额闭合 154,803 = 98,910+43,640+12,253 ✓